### PR TITLE
Fix argument passing for eyes commands.

### DIFF
--- a/lib/applitools-service.js
+++ b/lib/applitools-service.js
@@ -62,12 +62,12 @@ class ApplitoolService {
 
     // Add commands
     Object.keys(commands).forEach(function (key) {
-      browser.addCommand(key, function () {
+      browser.addCommand(key, function (...args) {
         // Set the stitch mode only if we're running the actual command
         // This prevents an issue where the CSS stitch move prevents scrolling on all tests
         this.eyes.setStitchMode(stitchMode);
 
-        return commands[key]();
+        return commands[key](...args);
       });
     })
   }


### PR DESCRIPTION
In current realization parameters for eyes commands are omitted. For example, if you have an error in `checkWindow` method the error message would be: `eyes.checkWindow: Difference in screenshot for undefined`
